### PR TITLE
Update SDK pod url to github

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -12,7 +12,7 @@ target 'OMGShop' do
   pod 'MBProgressHUD'
   pod 'Alamofire'
   pod 'KeychainSwift'
-  pod 'OmiseGO', :git => 'ssh://git@phabricator.omisego.io/source/sdk-ios.git'
+  pod 'OmiseGO', :git => 'git@github.com:omisego/ios-sdk.git'
   pod 'BigInt'
 
   target 'OMGShopTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,7 @@ PODS:
     - SipHash (~> 1.2)
   - KeychainSwift (10.0.0)
   - MBProgressHUD (1.1.0)
-  - OmiseGO (0.8.3)
+  - OmiseGO (0.9.0)
   - SipHash (1.2.0)
   - SkyFloatingLabelTextField (3.4.0)
   - Toaster (2.1.1)
@@ -15,31 +15,31 @@ DEPENDENCIES:
   - BigInt
   - KeychainSwift
   - MBProgressHUD
-  - OmiseGO (from `ssh://git@phabricator.omisego.io/source/sdk-ios.git`)
+  - OmiseGO (from `git@github.com:omisego/ios-sdk.git`)
   - SkyFloatingLabelTextField
   - Toaster
   - TPKeyboardAvoiding
 
 EXTERNAL SOURCES:
   OmiseGO:
-    :git: ssh://git@phabricator.omisego.io/source/sdk-ios.git
+    :git: git@github.com:omisego/ios-sdk.git
 
 CHECKOUT OPTIONS:
   OmiseGO:
-    :commit: ab36482dde380cd76942a2217f61201b30724f72
-    :git: ssh://git@phabricator.omisego.io/source/sdk-ios.git
+    :commit: 419e41b8175cde251f50939c6fd7654c5847c8a2
+    :git: git@github.com:omisego/ios-sdk.git
 
 SPEC CHECKSUMS:
   Alamofire: f41a599bd63041760b26d393ec1069d9d7b917f4
   BigInt: 8e8a52161c745cd3ab78e3dc346a9fbee51e6cf6
   KeychainSwift: f9f7910449a0c0fd2cabc889121530dd2c477c33
   MBProgressHUD: e7baa36a220447d8aeb12769bf0585582f3866d9
-  OmiseGO: a6ccfcdd36fd01533168108d9523e9869d177aee
+  OmiseGO: cade9dfb7e5760eac47bd6175acca70b4df234b9
   SipHash: c6e9e43e9c531b5bc6602545130c26194a6d31ce
   SkyFloatingLabelTextField: 703aa1420b697392b1e7dba25571180dde018477
   Toaster: a6c9532de1ded8105e77376f7dffeb2e12b46dbb
   TPKeyboardAvoiding: cb69d5ddbe90ce0170e4bc2db1e5e41d4a3ad9a4
 
-PODFILE CHECKSUM: edcac09ac2dbdd7382aadd5af8678fc3e83e5b58
+PODFILE CHECKSUM: 9d3da59ddef079cb41a8bf0d9b99c5c0b4414ba9
 
 COCOAPODS: 1.3.1


### PR DESCRIPTION
#We moved the SDK to github so the pod URL of the SDK needs to be updated in the sample app.
Also note that this URL will not be needed once the SDK is public.
  